### PR TITLE
feat(vercel ai sdk): migrated from v4 to v5

### DIFF
--- a/app/composables/chat-format.ts
+++ b/app/composables/chat-format.ts
@@ -1,12 +1,12 @@
 import type { DefineComponent } from 'vue'
-import type { Message } from '@ai-sdk/vue'
+import type { UIMessage } from '@ai-sdk/vue'
 import ProseStreamPre from '~/components/prose/PreStream.vue'
 
 const components = {
   pre: ProseStreamPre as unknown as DefineComponent,
 }
 
-function getUnwrap(role: Message['role']) {
+function getUnwrap(role: UIMessage['role']) {
   const tags = ['strong']
 
   if (role === 'user') {

--- a/app/composables/chat.ts
+++ b/app/composables/chat.ts
@@ -29,15 +29,6 @@ export function useChat(chat: MaybeRefOrGetter<Chat>) {
         messages,
       }
     },
-    onResponse() {
-      pending.value = true
-
-      if (scrollInterval.value) {
-        return clearInterval(scrollInterval.value)
-      }
-
-      scrollInterval.value = setInterval(scrollToBottom, 1000)
-    },
     onFinish() {
       pending.value = false
       if (scrollInterval.value) {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
 		"prepare": "husky"
 	},
 	"dependencies": {
-		"@ai-sdk/google": "^1.2.19",
-		"@ai-sdk/openai": "^1.3.22",
-		"@ai-sdk/vue": "^1.2.12",
+		"@ai-sdk/google": "^2.0.0-beta@latest",
+		"@ai-sdk/openai": "^2.0.0-beta@latest",
+		"@ai-sdk/vue": "^2.0.0-beta@latest",
 		"@iconify-json/lucide": "^1.2.46",
 		"@nuxt/eslint": "1.4.1",
 		"@nuxt/fonts": "0.11.4",
@@ -36,7 +36,7 @@
 		"@nuxtjs/mdc": "^0.17.0",
 		"@tailwindcss/vite": "^4.1.8",
 		"@vueuse/nuxt": "^13.3.0",
-		"ai": "^4.3.16",
+		"ai": "^5.0.0-beta@latest",
 		"better-auth": "^1.2.8",
 		"crypto-shield": "^1.6.2",
 		"daisyui": "^5.0.43",

--- a/server/api/v1/chats/[slug]/index.get.ts
+++ b/server/api/v1/chats/[slug]/index.get.ts
@@ -34,7 +34,7 @@ export default defineEventHandler(async (event) => {
         columns: {
           id: true,
           role: true,
-          content: true,
+          parts: true,
           tools: true,
         },
       },

--- a/server/api/v1/chats/[slug]/title.patch.ts
+++ b/server/api/v1/chats/[slug]/title.patch.ts
@@ -39,7 +39,7 @@ export default defineEventHandler(async (event) => {
           return asc(messages.createdAt)
         },
         columns: {
-          content: true,
+          parts: true,
         },
       },
     },
@@ -62,7 +62,8 @@ export default defineEventHandler(async (event) => {
     return null
   }
 
-  const initialMessages = chat.messages[0]!.content as string
+  // @ts-expect-error
+  const initialMessages = chat.messages[0]!.parts?.[0]?.text as string
   let title = ''
 
   switch (provider.id) {

--- a/server/api/v1/chats/new/index.put.ts
+++ b/server/api/v1/chats/new/index.put.ts
@@ -50,7 +50,10 @@ export default defineEventHandler(async (event) => {
     .values({
       chatId: chat.id,
       role: 'user',
-      content: body.data.message,
+      parts: [{
+        type: 'text',
+        text: body.data.message,
+      }],
       tools: body.data.tools,
     })
 

--- a/server/db/schemas/chats.ts
+++ b/server/db/schemas/chats.ts
@@ -1,3 +1,4 @@
+import type { UIMessage } from 'ai'
 import { relations, sql } from 'drizzle-orm'
 import {
   sqliteTable, text, integer, uniqueIndex,
@@ -32,7 +33,11 @@ export const messages = sqliteTable(
       .notNull()
       .references(() => chats.id, { onDelete: 'cascade' }),
     role: text({ enum: ['system', 'user', 'assistant'] }).notNull(),
-    content: text().notNull(),
+    parts: text({ mode: 'json' })
+      .notNull()
+      .$type<UIMessage['parts']>()
+      // .$type<Record<string, never>>()
+      .default(sql`'[]'`),
     tools: text({ mode: 'json' })
       .notNull()
       .$type<Array<'web_search'>>()

--- a/server/utils/chats/title.ts
+++ b/server/utils/chats/title.ts
@@ -1,8 +1,8 @@
-import type { LanguageModelV1 } from 'ai'
+import type { LanguageModel } from 'ai'
 import { generateText } from 'ai'
 
 export async function useChatTitle(
-  model: LanguageModelV1,
+  model: LanguageModel,
   message: string,
 ) {
   const instructions: string[] = [

--- a/server/utils/providers/google.ts
+++ b/server/utils/providers/google.ts
@@ -1,3 +1,4 @@
+import type { ProviderOptions } from 'ai'
 import type { Tools } from '#shared/types/chats.d'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 
@@ -30,9 +31,7 @@ export async function useGoogle(
   })
 
   function getInstance() {
-    return google(model, {
-      useSearchGrounding: requestedTools.includes('web_search'),
-    })
+    return google(model)
   }
 
   async function generateChatTitle(message: string) {
@@ -42,8 +41,25 @@ export async function useGoogle(
     )
   }
 
+  function getProviderOptions(): ProviderOptions {
+    if (!requestedTools?.length) {
+      return {}
+    }
+
+    const result: ProviderOptions = {}
+
+    if (requestedTools.includes('web_search')) {
+      result.google = {
+        useSearchGrounding: true,
+      }
+    }
+
+    return result
+  }
+
   return {
     instance: getInstance(),
     generateChatTitle,
+    providerOptions: getProviderOptions(),
   }
 }


### PR DESCRIPTION
Used related docs:
https://v5.ai-sdk.dev/docs/migration-guides/migration-guide-5-0

The only issue I met was custom error handling:
```
Object literal may only specify known properties, and 'getErrorMessage' does not exist in type 'ResponseInit & UIMessageStreamOptions'.ts(2353)
```
![image](https://github.com/user-attachments/assets/5c06528a-6b9b-4b41-b71b-d54094352f6e)
![image](https://github.com/user-attachments/assets/2d63b871-03f8-4f03-b16e-a5cb8f1742a1)

